### PR TITLE
Fix behavior when selecting multiple scheduled deliveries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2018-12-12
+
 ## [0.1.1] - 2018-12-06
 
 ## [0.1.0] - 2018-11-30

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "lean-shipping-calculator",
   "vendor": "vtex",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "title": "Checkout's Lean Shipping Calculator",
   "description": "Checkout's Lean Shipping Calculator",
   "defaultLocale": "en",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/lean-shipping-calculator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",

--- a/react/index.js
+++ b/react/index.js
@@ -155,9 +155,9 @@ function setSelectedSla({
       return
     }
 
-    const hasMandatoryScheduledDelivery = logisticsItem.slas.every(sla =>
-      hasDeliveryWindows(sla)
-    )
+    const hasMandatoryScheduledDelivery =
+      logisticsItem.slas.length === 1 &&
+      logisticsItem.slas.every(sla => hasDeliveryWindows(sla))
 
     const scheduledDelivery = logisticsItem.slas.find(sla =>
       hasDeliveryWindows(sla)

--- a/tests/fixtures/logisticsInfo-different-scheduled-delivery.js
+++ b/tests/fixtures/logisticsInfo-different-scheduled-delivery.js
@@ -1,7 +1,7 @@
 const DIFFERENT_SCHEDULED_DELIVERY_LOGISTICS_INFO = [
   {
     itemIndex: 0,
-    selectedSla: '',
+    selectedSla: 'agendada',
     selectedDeliveryChannel: '',
     addressId: '62e1db5500824a66bcef708d09388a8e',
     slas: [
@@ -45,7 +45,7 @@ const DIFFERENT_SCHEDULED_DELIVERY_LOGISTICS_INFO = [
   },
   {
     itemIndex: 1,
-    selectedSla: '',
+    selectedSla: 'outra agendada',
     selectedDeliveryChannel: '',
     addressId: '62e1db5500824a66bcef708d09388a8e',
     slas: [

--- a/tests/fixtures/logisticsInfo-scheduled-delivery.js
+++ b/tests/fixtures/logisticsInfo-scheduled-delivery.js
@@ -267,7 +267,157 @@ const SCHEDULED_DELIVERY_LOGISTICS_INFO = [
   },
 ]
 
+const MULTIPLE_MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO = [
+  {
+    itemIndex: 0,
+    selectedSla: 'outra agendada',
+    selectedDeliveryChannel: '',
+    addressId: '62e1db5500824a66bcef708d09388a8e',
+    slas: [
+      {
+        id: 'agendada',
+        deliveryChannel: 'delivery',
+        name: 'agendada',
+        deliveryIds: [
+          {
+            courierId: '1',
+            warehouseId: '1afe1cf',
+            dockId: '1b91c3b',
+            courierName: 'Courrier e-commerce',
+            quantity: 1,
+          },
+        ],
+        shippingEstimate: '0bd',
+        shippingEstimateDate: null,
+        lockTTL: null,
+        availableDeliveryWindows: [{}, {}],
+        deliveryWindow: null,
+        price: 334,
+        listPrice: 334,
+        tax: 0,
+        pickupStoreInfo: {
+          isPickupStore: false,
+          friendlyName: null,
+          address: null,
+          additionalInfo: null,
+          dockId: null,
+        },
+      },
+      {
+        id: 'outra agendada',
+        deliveryChannel: 'delivery',
+        name: 'outra agendada',
+        deliveryIds: [
+          {
+            courierId: '1',
+            warehouseId: '1afe1cf',
+            dockId: '1b91c3b',
+            courierName: 'Courrier e-commerce',
+            quantity: 1,
+          },
+        ],
+        shippingEstimate: '0bd',
+        shippingEstimateDate: null,
+        lockTTL: null,
+        availableDeliveryWindows: [{}, {}],
+        deliveryWindow: null,
+        price: 333,
+        listPrice: 333,
+        tax: 0,
+        pickupStoreInfo: {
+          isPickupStore: false,
+          friendlyName: null,
+          address: null,
+          additionalInfo: null,
+          dockId: null,
+        },
+      },
+    ],
+    shipsTo: ['BRA'],
+    itemId: '100006785',
+    deliveryChannels: [
+      {
+        id: 'delivery',
+      },
+    ],
+  },
+  {
+    itemIndex: 1,
+    selectedSla: 'outra agendada',
+    selectedDeliveryChannel: '',
+    addressId: '62e1db5500824a66bcef708d09388a8e',
+    slas: [
+      {
+        id: 'agendada',
+        deliveryChannel: 'delivery',
+        name: 'agendada',
+        deliveryIds: [
+          {
+            courierId: '1',
+            warehouseId: '1afe1cf',
+            dockId: '1b91c3b',
+            courierName: 'Courrier e-commerce',
+            quantity: 1,
+          },
+        ],
+        shippingEstimate: '0bd',
+        shippingEstimateDate: null,
+        lockTTL: null,
+        availableDeliveryWindows: [{}, {}],
+        deliveryWindow: null,
+        price: 333,
+        listPrice: 333,
+        tax: 0,
+        pickupStoreInfo: {
+          isPickupStore: false,
+          friendlyName: null,
+          address: null,
+          additionalInfo: null,
+          dockId: null,
+        },
+      },
+      {
+        id: 'outra agendada',
+        deliveryChannel: 'delivery',
+        name: 'outra agendada',
+        deliveryIds: [
+          {
+            courierId: '1',
+            warehouseId: '1afe1cf',
+            dockId: '1b91c3b',
+            courierName: 'Courrier e-commerce',
+            quantity: 1,
+          },
+        ],
+        shippingEstimate: '0bd',
+        shippingEstimateDate: null,
+        lockTTL: null,
+        availableDeliveryWindows: [{}, {}],
+        deliveryWindow: null,
+        price: 333,
+        listPrice: 333,
+        tax: 0,
+        pickupStoreInfo: {
+          isPickupStore: false,
+          friendlyName: null,
+          address: null,
+          additionalInfo: null,
+          dockId: null,
+        },
+      },
+    ],
+    shipsTo: ['BRA'],
+    itemId: '100006786',
+    deliveryChannels: [
+      {
+        id: 'delivery',
+      },
+    ],
+  },
+]
+
 module.exports = {
   MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO,
   SCHEDULED_DELIVERY_LOGISTICS_INFO,
+  MULTIPLE_MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO,
 }

--- a/tests/lean-shipping-options.test.js
+++ b/tests/lean-shipping-options.test.js
@@ -6,6 +6,7 @@ import { SAME_ID_LOGISTICS_INFO } from './fixtures/logisticsInfo-sameId'
 import {
   SCHEDULED_DELIVERY_LOGISTICS_INFO,
   MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO,
+  MULTIPLE_MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO,
 } from './fixtures/logisticsInfo-scheduled-delivery'
 import { DIFFERENT_SCHEDULED_DELIVERY_LOGISTICS_INFO } from './fixtures/logisticsInfo-different-scheduled-delivery'
 
@@ -153,6 +154,32 @@ describe('Check if getLeanShippingOptions', () => {
         },
         {
           selectedSla: 'Expressa',
+        },
+      ],
+    }
+
+    expect(result.cheapest[0].selectedSla).toEqual(
+      expectedResult.cheapest[0].selectedSla
+    )
+    expect(result.cheapest[1].selectedSla).toEqual(
+      expectedResult.cheapest[1].selectedSla
+    )
+    expect(result.fastest).toBeUndefined()
+  })
+
+  it('should maintain selected scheduled delivery', () => {
+    const result = getLeanShippingOptions({
+      logisticsInfo: MULTIPLE_MANDATORY_SCHEDULED_DELIVERY_LOGISTICS_INFO,
+      activeChannel: DELIVERY,
+    })
+
+    const expectedResult = {
+      cheapest: [
+        {
+          selectedSla: 'outra agendada',
+        },
+        {
+          selectedSla: 'outra agendada',
         },
       ],
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
If scheduled delivery is active, and logisticsInfo already has a scheduled delivery selected, lean shipping should maintain it selected.

#### What problem is this solving?
- Calculator would select the default scheduled delivery when it should maintain the current scheduled delivery selected.

#### How should this be manually tested?
`yarn test`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
