### PR TITLE
Update pickup selection considering if have single or multiple items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Selecting pickup points considering if have single or multiple items
+
 ## [0.2.4] - 2019-08-06
 
 ### Changed

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -5,7 +5,11 @@ import {
   findChannelById,
 } from '@vtex/delivery-packages/dist/delivery-channel'
 import { helpers } from 'vtex.address-form'
-import { isFromCurrentSeller, hasCurrentDeliveryChannel, findSlaWithChannel } from './utils'
+import {
+  isFromCurrentSeller,
+  hasCurrentDeliveryChannel,
+  findSlaWithChannel,
+} from './utils'
 const { removeValidation } = helpers
 
 export function getNewLogisticsInfoIfPickup({
@@ -15,6 +19,7 @@ export function getNewLogisticsInfoIfPickup({
   canEditData,
   firstPickupSla,
   logisticsInfo,
+  hasMultipleItems,
 }) {
   if (
     firstPickupSla &&
@@ -53,14 +58,16 @@ export function getNewLogisticsInfoIfPickup({
       !defaultSlaSelection)
   ) {
     const defaultDeliverySla = findSlaWithChannel(logisticsInfo, DELIVERY)
-
     return {
       ...logisticsInfo,
-      addressId: defaultDeliverySla
-        ? actionAddress.addressId
-        : actionSearchAddress.addressId,
-      selectedDeliveryChannel: defaultDeliverySla ? DELIVERY : channel,
-      selectedSla: defaultDeliverySla ? defaultDeliverySla.id : null,
+      addressId:
+        defaultDeliverySla && hasMultipleItems
+          ? actionAddress.addressId
+          : actionSearchAddress.addressId,
+      selectedDeliveryChannel:
+        defaultDeliverySla && hasMultipleItems ? DELIVERY : channel,
+      selectedSla:
+        defaultDeliverySla && hasMultipleItems ? defaultDeliverySla.id : null,
     }
   }
 
@@ -77,7 +84,6 @@ export function getNewLogisticsInfoIfPickup({
       isPickup(channel) &&
       firstPickupSla &&
       (canEditData || hasDifferentGeoCoordinates)
-
     return {
       ...logisticsInfo,
       selectedDeliveryChannel: channel,
@@ -96,7 +102,9 @@ export function getNewLogisticsInfoIfPickup({
     selectedDeliveryChannel: hasCurrentDeliveryChannel(logisticsInfo, channel)
       ? channel
       : DELIVERY,
-    addressId: actionSearchAddress.addressId,
+    addressId: hasCurrentDeliveryChannel(logisticsInfo, channel)
+      ? actionSearchAddress.addressId
+      : actionAddress.addressId,
     selectedSla: null,
   }
 }
@@ -169,6 +177,7 @@ export function getNewLogisticsInfo({
         canEditData,
         firstPickupSla: slaFromSlaOption || firstPickupSla,
         logisticsInfo: li,
+        hasMultipleItems: newLogisticsInfo.length > 1,
       })
 
       if (newLogisticsInfoIfPickup) {

--- a/tests/change-active-slas.test.js
+++ b/tests/change-active-slas.test.js
@@ -126,7 +126,7 @@ describe('changeActiveSlas', () => {
     expect(result[0].addressId).toEqual('searchId')
   })
 
-  it('switch with multiple logistics info with both Delivery Channels and has slas but one does not have pickup', () => {
+  it('switches with multiple logistics info with both Delivery Channels and has slas but one does not have pickup', () => {
     const logisticsInfo = MULTIPLE_DELIVERY_PICKUP_LOGISTICS_INFO
     const action = {
       address: {
@@ -197,7 +197,7 @@ describe('changeActiveSlas', () => {
     expect(result[0].addressId).toEqual('searchId')
   })
 
-  it('switch with one logistics info with both Delivery Channels and no pickup points', () => {
+  it('switches with one logistics info with both Delivery Channels and no pickup points', () => {
     const logisticsInfo = NO_PICKUP_SELECTED_LOGISTICS_INFO
     const action = {
       address: {

--- a/tests/change-active-slas.test.js
+++ b/tests/change-active-slas.test.js
@@ -10,6 +10,7 @@ import {
   PICKUP_SELECTED_LOGISTICS_INFO,
   MULTIPLE_SELLERS_LOGISTICS_INFO,
   MULTIPLE_DELIVERY_PICKUP_LOGISTICS_INFO,
+  NO_PICKUP_SELECTED_LOGISTICS_INFO,
 } from './fixtures/logisticsInfo-changeActiveSlas'
 
 describe('changeActiveSlas', () => {
@@ -125,7 +126,7 @@ describe('changeActiveSlas', () => {
     expect(result[0].addressId).toEqual('searchId')
   })
 
-  it('switch with one logistics info with both Delivery Channels and has slas but one does not have pickup', () => {
+  it('switch with multiple logistics info with both Delivery Channels and has slas but one does not have pickup', () => {
     const logisticsInfo = MULTIPLE_DELIVERY_PICKUP_LOGISTICS_INFO
     const action = {
       address: {
@@ -193,6 +194,40 @@ describe('changeActiveSlas', () => {
 
     expect(result[0].selectedDeliveryChannel).toEqual(PICKUP_IN_STORE)
     expect(result[0].selectedSla).toEqual('pickupSlaSelected')
+    expect(result[0].addressId).toEqual('searchId')
+  })
+
+  it('switch with one logistics info with both Delivery Channels and no pickup points', () => {
+    const logisticsInfo = NO_PICKUP_SELECTED_LOGISTICS_INFO
+    const action = {
+      address: {
+        addressId: { value: 'residentialId' },
+        addressType: { value: 'residential' },
+        postalCode: { value: 'testPostalCode' },
+      },
+      searchAddress: {
+        addressId: { value: 'searchId' },
+        addressType: { value: 'search' },
+        postalCode: { value: 'testPostalCode' },
+      },
+    }
+    const items = [{ seller: '1' }]
+    const sellers = [{ id: '1' }]
+    const canEditData = true
+    const slaOption = 'pickupSlaSelected'
+
+    const result = changeActiveSlas({
+      logisticsInfo,
+      action,
+      items,
+      sellers,
+      channel: PICKUP_IN_STORE,
+      canEditData,
+      slaOption,
+    })
+
+    expect(result[0].selectedDeliveryChannel).toEqual(PICKUP_IN_STORE)
+    expect(result[0].selectedSla).toBeNull()
     expect(result[0].addressId).toEqual('searchId')
   })
 

--- a/tests/fixtures/logisticsInfo-changeActiveSlas.js
+++ b/tests/fixtures/logisticsInfo-changeActiveSlas.js
@@ -27,9 +27,6 @@ const ONLY_DELIVERY_LOGISTICS_INFO = [
       {
         id: DELIVERY,
       },
-      {
-        id: PICKUP_IN_STORE,
-      },
     ],
     slas: [
       {
@@ -100,7 +97,7 @@ const MULTIPLE_DELIVERY_PICKUP_LOGISTICS_INFO = [
   },
   {
     addressId: 'residentialId',
-    itemIndex: 0,
+    itemIndex: 1,
     selectedDeliveryChannel: DELIVERY,
     deliveryChannels: [
       {
@@ -148,6 +145,30 @@ const PICKUP_SELECTED_LOGISTICS_INFO = [
       {
         id: 'pickupSlaSelected',
         deliveryChannel: PICKUP_IN_STORE,
+        availableDeliveryWindows: [],
+      },
+    ],
+    selectedSla: 'deliverySLA',
+  },
+]
+
+const NO_PICKUP_SELECTED_LOGISTICS_INFO = [
+  {
+    addressId: 'residentialId',
+    itemIndex: 0,
+    selectedDeliveryChannel: DELIVERY,
+    deliveryChannels: [
+      {
+        id: DELIVERY,
+      },
+      {
+        id: PICKUP_IN_STORE,
+      },
+    ],
+    slas: [
+      {
+        id: 'deliverySLA',
+        deliveryChannel: DELIVERY,
         availableDeliveryWindows: [],
       },
     ],
@@ -217,4 +238,5 @@ module.exports = {
   PICKUP_SELECTED_LOGISTICS_INFO,
   MULTIPLE_SELLERS_LOGISTICS_INFO,
   MULTIPLE_DELIVERY_PICKUP_LOGISTICS_INFO,
+  NO_PICKUP_SELECTED_LOGISTICS_INFO,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update pickup selection considering if have single or multiple items

#### What problem is this solving?
Closes [story](https://app.clubhouse.io/vtex/story/17760)

#### How should this be manually tested?
1. Add [item to cart](https://pickup--demochile.myvtex.com/checkout/cart/add/?sku=1&qty=1&seller=1&sc=1)
2. Go to Pickup and search for "santiago, chile"
3. Choose the first pickup point
4. Go to Delivery
5. Search for "La Oración, Coquimbo"
6. Go back to pickup and it should return to the selected pickup point

#### Screenshots or example usage
n/a
#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
