### PR TITLE
Fix error with scheduled delivery in no lean scenario

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,1 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "trailingComma": "es5",
-  "jsxBracketSameLine": true,
-  "eslintIntegration": true
-}
+"@vtex/prettier-config"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `setSelectedSlaFromSlaOption` only sets the SLA of items that have that SLA.
+
 ## [0.2.5] - 2019-08-14
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "@vtex/address-form": "^3.5.12",
+    "@vtex/prettier-config": "^0.1.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.2",

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -129,7 +129,7 @@ export function getNewLogisticsInfoIfDelivery({
   if (
     hasCurrentDeliveryChannel(logisticsInfo, channel) &&
     slaFromSlaOption &&
-    logisticsInfo.slas.find(sla => sla.id === slaFromSlaOption.id)
+    logisticsInfo.slas.some(sla => sla.id === slaFromSlaOption.id)
   ) {
     return {
       ...logisticsInfo,

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -126,7 +126,11 @@ export function getNewLogisticsInfoIfDelivery({
     }
   }
 
-  if (hasCurrentDeliveryChannel(logisticsInfo, channel) && slaFromSlaOption) {
+  if (
+    hasCurrentDeliveryChannel(logisticsInfo, channel) &&
+    slaFromSlaOption &&
+    logisticsInfo.slas.find(sla => sla.id === slaFromSlaOption.id)
+  ) {
     return {
       ...logisticsInfo,
       addressId: actionAddress.addressId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -137,6 +137,11 @@
   dependencies:
     lodash "^4.17.5"
 
+"@vtex/prettier-config@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@vtex/prettier-config/-/prettier-config-0.1.4.tgz#dc7633c5b511e42673830503d88adde7da17f40a"
+  integrity sha512-/rNzJ7R7KZmmcrCS3GFbVhfQRKFYFsDvCyO3Mv+atyILi0dkiELLVHUrbeAV/VaCgEMAGgWB9rdCQRasI3Yy/w==
+
 "@vtex/styleguide@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@vtex/styleguide/-/styleguide-5.6.2.tgz#133ac2d7847b148f4b1bdb836b999cb90d667c22"


### PR DESCRIPTION
#### What is the purpose of this pull request?
This fixes an issue with Omnishipping with no leanshipping (both in `master` and refactor branches) where trying to change the delivery SLA would result in an error: `Uncaught TypeError: Cannot read property 'shippingEstimate' of undefined` ([Related Clubhouse story](https://app.clubhouse.io/vtex/story/35332/erro-ao-trocar-sla-em-carrinho-com-delivery-e-scheduled-delivery)).

_Detailed description:_

When leanshipping is disabled, the "on SLA change" event is handled by the [`changeActiveSLAOption`](https://github.com/vtex/omnishipping/blob/master/react/components/DeliveryOptionsList.js#L8) action. The delivery reducer for this action [calls a `setSelectedSlaFromSlaOption` function](https://github.com/vtex/omnishipping/blob/master/react/reducers/delivery-reducer.js#L410) from `vtex.lean-shipping-calculator` (this repository). This function will [set the SLAs of ***all*** delivery items to the selected SLA](https://github.com/vtex/lean-shipping-calculator/blob/master/react/logisticsInfo.js#L112). This includes scheduled delivery items which might not have the SLA being set.

This is usually not a problem because the API ignores "illegal" SLA changes AFAIK. However, further down the delivery reducer, a [`getOptionsDetails` function is called](https://github.com/vtex/omnishipping/blob/master/react/reducers/delivery-reducer.js#L469) (also a function from `vtex.lean-shipping-calculator`). This breaks, because [it tries to get the SLA object with same `id` as the `selectedSla` for each item](https://github.com/vtex/lean-shipping-calculator/blob/master/react/DeliveryPackagesUtils.js#L183), but the item with scheduled delivery does not have it.

The fix was to prevent `setSelectedSlaFromSlaOption` from setting the `selectedSla` value of delivery items that do not have that SLA.

#### How should this be manually tested?
1. In `vtexgame1nolean`, [add these two items to cart](https://schdel--vtexgame1nolean.myvtex.com/checkout/cart/add?sku=289&qty=1&seller=1&sku=291&qty=1&seller=1) (delivery + scheduled delivery).
2. Proceed to checkout, fill profile.
3. In Omnishipping, enter `22250-040` as postal-code.
4. Try to change the non-scheduled SLA. It should work.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
