### PR TITLE
Fix error with scheduled delivery in no lean scenario (Pickup channel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- In Pickup channel, `setSelectedSlaFromSlaOption` only sets the SLA of items that have that SLA.
+
 ## [0.2.6] - 2020-04-07
 
 ### Fixed

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -29,8 +29,12 @@ export function getNewLogisticsInfoIfPickup({
     return logisticsInfo
   }
 
-  if (
+  const hasFirstPickupSla =
     firstPickupSla &&
+    logisticsInfo.slas.some(sla => sla.id === firstPickupSla.id)
+
+  if (
+    hasFirstPickupSla &&
     findChannelById(logisticsInfo, firstPickupSla.deliveryChannel) &&
     firstPickupSla.deliveryChannel === DELIVERY
   ) {
@@ -40,7 +44,7 @@ export function getNewLogisticsInfoIfPickup({
       selectedDeliveryChannel: firstPickupSla
         ? firstPickupSla.deliveryChannel
         : null,
-      selectedSla: firstPickupSla ? firstPickupSla.id : null,
+      selectedSla: firstPickupSla.id,
     }
   }
 
@@ -91,7 +95,7 @@ export function getNewLogisticsInfoIfPickup({
         ? actionSearchAddress.addressId
         : actionAddress.addressId,
       selectedSla:
-        isPickup(channel) && firstPickupSla
+        isPickup(channel) && hasFirstPickupSla
           ? firstPickupSla.id
           : defaultSlaSelection.id,
     }
@@ -105,7 +109,6 @@ export function getNewLogisticsInfoIfPickup({
     addressId: hasCurrentDeliveryChannel(logisticsInfo, channel)
       ? actionSearchAddress.addressId
       : actionAddress.addressId,
-    selectedSla: null,
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is a follow up of https://github.com/vtex/lean-shipping-calculator/pull/32.

When there's a pickup item in the cart, the pickup channel gets activated and a different function is called to update each item's `logisticsInfo`. This PR covers this case that was not covered by the mentioned PR.

#### How should this be manually tested?
1. In `vtexgame1nolean`, [add these items to cart](https://schdel--vtexgame1nolean.myvtex.com/checkout/cart/add?sku=285&qty=1&seller=1&sku=289&qty=1&seller=1&sku=291&qty=1&seller=1) (pickup + delivery + scheduled delivery).
2. Proceed to checkout, fill profile.
3. In Omnishipping, change to Pickup tab and scroll to delivery.
4. Try changing the non-scheduled delivery SLA. It should work and should not reset the scheduled delivery component.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
