### PR TITLE
Exclude all-scheduled logistic info from lean shipping calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Excludes all-scheduled logistic info from lean shipping calculation.
+
 ## [0.2.7] - 2020-04-08
 
 ### Fixed

--- a/react/leanShipping.js
+++ b/react/leanShipping.js
@@ -136,57 +136,17 @@ function setSelectedSla({
   logisticsInfo,
   selectedSlas,
   activeChannel,
-  isScheduledDeliveryActive,
 }) {
   const newLogisticsInfo = []
 
-  const hasItemWithMandatoryScheduledDelivery = logisticsInfo.some(li =>
-    li.slas.every(sla => hasDeliveryWindows(sla))
-  )
-
   logisticsInfo.forEach((logisticsItem, index) => {
+    const hasMandatoryScheduledDelivery = logisticsItem.slas.length && logisticsItem.slas.every(sla => hasDeliveryWindows(sla))
+
     if (
       isUnavailable(logisticsItem) ||
-      (isPickup(logisticsItem) && isPickup(activeChannel))
+      (isPickup(logisticsItem) && isPickup(activeChannel)) || hasMandatoryScheduledDelivery
     ) {
       newLogisticsInfo.push(logisticsItem)
-
-      return
-    }
-
-    const hasMandatoryScheduledDelivery =
-      logisticsItem.slas.length === 1 &&
-      logisticsItem.slas.every(
-        sla => isCurrentChannel(sla, activeChannel) && hasDeliveryWindows(sla)
-      )
-
-    const scheduledDelivery = logisticsItem.slas.find(
-      sla => isCurrentChannel(sla, activeChannel) && hasDeliveryWindows(sla)
-    )
-
-    if (
-      ((isScheduledDeliveryActive || hasMandatoryScheduledDelivery) &&
-        scheduledDelivery) ||
-      (hasItemWithMandatoryScheduledDelivery && scheduledDelivery)
-    ) {
-      const selectedSla = logisticsItem.slas.find(
-        sla => sla.id === logisticsItem.selectedSla
-      )
-
-      const shouldUseSelectedSla =
-        !hasMandatoryScheduledDelivery &&
-        selectedSla &&
-        hasDeliveryWindows(selectedSla)
-
-      newLogisticsInfo.push({
-        ...logisticsItem,
-        selectedSla: shouldUseSelectedSla
-          ? selectedSla.id
-          : scheduledDelivery.id,
-        selectedDeliveryChannel: shouldUseSelectedSla
-          ? selectedSla.deliveryChannel
-          : scheduledDelivery.deliveryChannel,
-      })
 
       return
     }
@@ -362,14 +322,12 @@ export function getLeanShippingOptions({
     logisticsInfo,
     selectedSlas: selectedSlas.cheapest,
     activeChannel,
-    isScheduledDeliveryActive,
   })
 
   const fastest = setSelectedSla({
     logisticsInfo,
     selectedSlas: selectedSlas.fastest,
     activeChannel,
-    isScheduledDeliveryActive,
   })
 
   const fastestAndCheapestAreEqual = isEqual(cheapest, fastest)
@@ -381,7 +339,6 @@ export function getLeanShippingOptions({
       logisticsInfo,
       selectedSlas: selectedSlas.fastest,
       activeChannel,
-      isScheduledDeliveryActive,
     })
   }
 

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -150,7 +150,7 @@ export function getNewLogisticsInfoIfDelivery({
       ...logisticsInfo,
       addressId: actionAddress.addressId,
       selectedDeliveryChannel: channel,
-      selectedSla: defaultSlaSelection.id,
+      selectedSla: logisticsInfo.selectedSla || defaultSlaSelection.id,
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

This PR intends to exclude an all-scheduled logistic info from lean shipping calculation. That way, the user can choose among the scheduled options being presented, even when there's items with pickup on the cart. Which is not possible today on `master`.

It also prevents SLA selectors from being reset every time the active tab on `omnishipping ` changes from delivery to pickup.

#### How should this be manually tested?

You can follow the test plan for `vtexgame1` described [here](https://github.com/vtex/shipping-manager/pull/23)

Besides that, the selected SLAs shouldn't change when switching tabs on `omnishipping`.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/79397080-a413de00-7f53-11ea-807c-67a2447c85db.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
