### PR TITLE
Fix scheduled SLAs in Omnishipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Scheduled SLAs are no longer taken into consideration when calculating lean shipping options.
+
 ## [0.2.7] - 2020-04-08
 
 ### Fixed

--- a/react/leanShipping.js
+++ b/react/leanShipping.js
@@ -79,14 +79,10 @@ export function getSelectedDeliveryOption({
     : activeDeliveryOption
 }
 
-function filterSlasByChannel(slas, isScheduledDeliveryActive) {
+function filterSlasByChannel(slas) {
   if (!slas) return
 
-  return slas.filter(sla =>
-    hasOnlyScheduledDelivery(slas) || isScheduledDeliveryActive
-      ? isDelivery(sla)
-      : isDelivery(sla) && !hasDeliveryWindows(sla)
-  )
+  return slas.filter(sla => isDelivery(sla) && !hasDeliveryWindows(sla))
 }
 
 function getSlaAccumulatedPrice(sla, logisticsInfo) {
@@ -108,12 +104,9 @@ function createArrayOfSlasObject(slas, logisticsInfo) {
   }))
 }
 
-function createArraysOfSlas(logisticsInfo, isScheduledDeliveryActive) {
+function createArraysOfSlas(logisticsInfo) {
   return logisticsInfo.map(item => {
-    const filteredByChannel = filterSlasByChannel(
-      item.slas,
-      isScheduledDeliveryActive
-    )
+    const filteredByChannel = filterSlasByChannel(item.slas)
 
     return filteredByChannel.length
       ? createArrayOfSlasObject(filteredByChannel, logisticsInfo)
@@ -349,10 +342,7 @@ export function getLeanShippingOptions({
   activeChannel = DELIVERY,
   isScheduledDeliveryActive = false,
 }) {
-  const arraysOfSlas = createArraysOfSlas(
-    logisticsInfo,
-    isScheduledDeliveryActive
-  )
+  const arraysOfSlas = createArraysOfSlas(logisticsInfo)
   const selectedSlas = {
     cheapest: getMinSlaBy(arraysOfSlas, 'price'),
     fastest: getMinSlaBy(arraysOfSlas, 'shippingEstimateInSeconds'),

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -142,15 +142,12 @@ export function getNewLogisticsInfoIfDelivery({
     }
   }
 
-  if (
-    hasCurrentDeliveryChannel(logisticsInfo, channel) &&
-    defaultSlaSelection
-  ) {
+  if (hasCurrentDeliveryChannel(logisticsInfo, channel)) {
     return {
       ...logisticsInfo,
       addressId: actionAddress.addressId,
       selectedDeliveryChannel: channel,
-      selectedSla: defaultSlaSelection.id,
+      selectedSla: logisticsInfo.selectedSla || defaultSlaSelection.id,
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

**Note:** This must be merged **after** https://github.com/vtex/shipping-preview/pull/197, otherwise it will break Omnishipping.

This is a fix composed of 3 PRs in different repos ([`omnishipping`](https://github.com/vtex/omnishipping/pull/1325), [`shipping-manager`](https://github.com/vtex/shipping-manager/pull/25) and this one). Check [`shipping-manager`'s PR](https://github.com/vtex/shipping-manager/pull/25) for the full description of the fix.

This PR in particular prevents `lean-shipping-calculator` from taking scheduled SLAs in consideration when calculating the "lean" option.

#### How should this be manually tested?
Follow the test plan of [this PR](https://github.com/vtex/shipping-manager/pull/25).

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
