### PR TITLE
Fix/scheduled options not shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `hasItemWithMandatoryScheduledDelivery` only evaluates to `true` if all SLAs have `delivery` as their delivery channel.
+
 ## [0.2.8] - 2020-04-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `hasItemWithMandatoryScheduledDelivery` only evaluates to `true` if all SLAs have `delivery` as their delivery channel.
+- `hasItemWithMandatoryScheduledDelivery` only evaluates to `true` if all the SLAs have `delivery` as their delivery channel.
 
 ## [0.2.8] - 2020-04-20
 

--- a/react/leanShipping.js
+++ b/react/leanShipping.js
@@ -134,7 +134,7 @@ function setSelectedSla({
   const newLogisticsInfo = []
 
   const hasItemWithMandatoryScheduledDelivery = logisticsInfo.some(li =>
-    li.slas.every(sla => hasDeliveryWindows(sla))
+    li.slas.every(sla => hasDeliveryWindows(sla) && isDelivery(sla))
   )
 
   logisticsInfo.forEach((logisticsItem, index) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

This PR intends to close [story 36500](https://app.clubhouse.io/vtex/story/36500/delivery-channel-incorreto-ao-alternar-de-pickup-para-delivery).

The problem was that `hasItemWithMandatoryScheduledDelivery` was evaluating to `true` when a `logisticsInfo` had only scheduled pickup SLAs, besides the scheduled delivery ones. With that, the `selectedDeliveryChannel` wasn't updated properly.

To solve that, I'm now checking if the SLA has `delivery` as its delivery channel.

#### How should this be manually tested?

- Proceed to the [workspace](https://jeff--devotoweb.vtexcommercestable.com.br/checkout/cart/add/?sku=24102&qty=1&seller=1&sc=3)
- Proceed to checkout
- Use `11111111` as document and `44444444` as phone
- Use the address `Zudañez 2627`
- Go to pickup
- Go back to delivery
- Check if the scheduled delivery option is still being shown (as in the image below)

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/80686862-c7847000-8a9f-11ea-9f91-465d83a632a0.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
