### PR TITLE
Fix pickup SLA selected when switching from pickup to delivery as the…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pickup SLAs can not be selected when the `selectedDeliveryChannel` is `delivery`.
+
 ## [0.2.9] - 2020-04-30
 
 ### Fixed

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -6,6 +6,7 @@ import {
 } from '@vtex/delivery-packages/dist/delivery-channel'
 import { helpers } from 'vtex.address-form'
 import {
+  findSlaOption,
   isFromCurrentSeller,
   hasCurrentDeliveryChannel,
   findSlaWithChannel,
@@ -142,12 +143,15 @@ export function getNewLogisticsInfoIfDelivery({
     }
   }
 
+  const selectedSla = findSlaOption([logisticsInfo], logisticsInfo.selectedSla)
+  const shouldUseSelectedSla = selectedSla && selectedSla.deliveryChannel === channel
+
   if (hasCurrentDeliveryChannel(logisticsInfo, channel)) {
     return {
       ...logisticsInfo,
       addressId: actionAddress.addressId,
       selectedDeliveryChannel: channel,
-      selectedSla: logisticsInfo.selectedSla || defaultSlaSelection.id,
+      selectedSla: shouldUseSelectedSla ? logisticsInfo.selectedSla : defaultSlaSelection.id,
     }
   }
 }


### PR DESCRIPTION
… selected delivery channel

#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

The aim of this PR is to fix a problem which was causing shipping-preview to break when switching from the pickup tab to the delivery tab. That happened because the `selectedSla` wasn't being properly updated, since a pickup SLA would be selected when the user switched to the delivery tab.

#### How should this be manually tested?

- Proceed to this [workspace](https://fixswitchingtab--lojaibyte.myvtex.com/checkout/cart/add/?sku=4121&qty=1&seller=1&sc=1)
- Use `60743-155` as the postal code
- Switch to the pickup tab
- Switch back to the delivery tab
- You should see the selected SLA (as in the image below) and the SP shouldn't break

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/81568530-487f1980-9374-11ea-9f2e-7813f3b3cde3.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
