### PR TITLE
CHK-320: Find the cheapest SLA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `findSlaWithChannel` now returns the cheapest SLA.
+
 ## [0.2.10] - 2020-05-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-jest": "^21.12.2",
     "husky": "^1.2.0",
     "jest": "^22.3.0",
+    "prettier": "^2.1.2",
     "react": "^16.8.6",
     "react-intl": "^2.9.0",
     "regexpp": "^2.0.1",

--- a/react/utils.js
+++ b/react/utils.js
@@ -167,11 +167,13 @@ export function findSlaWithChannel(item, channel) {
     )
   })
 
-  let cheapestSla = !!currentChannelSlas.length && currentChannelSlas[0]
+  let cheapestSla = currentChannelSlas[0]
 
-  currentChannelSlas.forEach(sla => {
-    cheapestSla = sla.price < cheapestSla.price ? sla : cheapestSla
-  })
+  if (cheapestSla) {
+    currentChannelSlas.forEach(sla => {
+      cheapestSla = sla.price < cheapestSla.price ? sla : cheapestSla
+    })
+  }
 
   return cheapestSla
 }

--- a/react/utils.js
+++ b/react/utils.js
@@ -151,13 +151,27 @@ export function hasPostalCodeGeocoordinates(address, searchAddress) {
 }
 
 export function findSlaWithChannel(item, channel) {
-  return (
-    item &&
-    item.slas &&
-    item.slas.find(sla =>
-      hasOnlyScheduledDelivery(item.slas, channel)
-        ? isCurrentChannel(sla, channel)
-        : isCurrentChannel(sla, channel) && !hasDeliveryWindows(sla)
-    )
+  if (!item || !item.slas) {
+    return null
+  }
+
+  const hasOnlyScheduledDeliverySla = hasOnlyScheduledDelivery(
+    item.slas,
+    channel
   )
+
+  const currentChannelSlas = item.slas.filter(sla => {
+    return (
+      isCurrentChannel(sla, channel) &&
+      (!hasDeliveryWindows(sla) || hasOnlyScheduledDeliverySla)
+    )
+  })
+
+  let cheapestSla = !!currentChannelSlas.length && currentChannelSlas[0]
+
+  currentChannelSlas.forEach(sla => {
+    cheapestSla = sla.price < cheapestSla.price ? sla : cheapestSla
+  })
+
+  return cheapestSla
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,6 +3572,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
+  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+
 pretty-format@^22.1.0:
   version "22.1.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.1.0.tgz#2277605b40ed4529ae4db51ff62f4be817647914"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

The aim of this PR is to make `findSlaWithChannel` function return the cheapest SLA. That function is used to return a SLA which will be the `selectedSla` when the lean shipping is off.

With this change, now when the user changes the active tab to `delivery`, he will see the cheapest SLA selected.

#### How should this be manually tested?

- [Add an item to cart](https://jeff--calcadosbibi.myvtex.com/checkout/cart/add/?sku=55844&qty=1&seller=1&sc=1)
- Use `95670-000`
- Change to pickup in point
- Go back to delivery
- You should see the cheapest SLA selected

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12574426/98221241-284ca380-1f2e-11eb-93cf-90c9ba4b6064.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
