### PR TITLE
FO-126 - Use consistency of SLA's through items as a tiebreaker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use consistency of SLA's through items as a tiebreaker.
+
 ## [0.2.11] - 2020-11-17
 
 ### Changed


### PR DESCRIPTION
#### What is the purpose of this pull request?
To give preference to SLA's that serve the entire cart and optimize number of packages in each delivery.

#### What problem is this solving?
The tiebreaker between similar prices or estimate time was simply the order of the array. This was leading us to inconsistent SLA's selections. By identifying which are the consistent SLA's through the entire cart (the ones that are able to deliver every item) and reordering the array putting these ones first, we give preference to them.

#### How should this be manually tested?
1. Go to [this cart](https://fo126--trackfield.myvtex.com/checkout/?orderFormId=e4f8c33e7d964766ba8e34e10b56c383#/cart).
2. The cart should be deliverable in **one** package.

#### Screenshots or example usage

How it was:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/11471014/127192792-cb127e53-c2a6-4dbe-8392-c2518ea2e0bd.png">

How it should be:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/11471014/127192682-510626de-bdc1-4e7f-9846-24b7795849ae.png">

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
