### PR TITLE
CHK-868: Temporary log debug metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Debug logs for getLeanShippingOptions function
+
 ## [0.2.13] - 2021-09-21
 
 ### Fixed

--- a/react/leanShipping.js
+++ b/react/leanShipping.js
@@ -534,7 +534,9 @@ function logReport(report) {
     account: getAccountName(),
   }
 
-  window.logSplunk && window.logSplunk(log)
+  if (Math.random() < 0.1) {
+    window.logSplunk && window.logSplunk(log)
+  }
 }
 
 export function getLeanShippingOptions({


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add debug logs to lean shipping getLeanShippingOptions function, so we can better understand if #54 improved our old solution for lean shipping selection.

Log data:

- orderFormId
- numberOfAvailableSlas
- CheapestProfit
- CheapestNumberOfSelectedSlas
- CheapestSelectedMethod
- CheapestCurrentMethodIsValid
- CheapestIndividualMethodIsValid
- CheapestConsistentMethodIsValid
- FastestProfit
- FastestNumberOfSelectedSlas
- FastestSelectedMethod
- FastestCurrentMethodIsValid
- FastestIndividualMethodIsValid
- FastestConsistentMethodIsValid

Maybe some of those logs aren't so relevant, but they seem like a good start. Also, **they will be removed later on**

#### How should this be manually tested?

You can check the generated logs when the E2E tests were executed.

[Splunk link](https://splunk7.vtex.com/en-US/app/search/search?q=search%20index%3Dcheckout_ui%20workflowInstance%3Dget-lean-shipping-options&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=1632786000&latest=1632787200&sid=1632839334.76222_79C7A458-EB9B-481B-BCD2-A322D7B50769)