### PR TITLE
CHK-1924: Fix calculation of packages length not considering SLA estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Calculation of `packagesLength` not considering SLA estimate.
 
 ## [0.2.17] - 2022-07-06
 ### Fixed

--- a/react/DeliveryPackagesUtils.js
+++ b/react/DeliveryPackagesUtils.js
@@ -39,7 +39,11 @@ function getPackagesLength(chosenPackage) {
     flatten(
       chosenPackage
         .filter(li => isDelivery(li) && (!!li.selectedSla || hasSLAs(li)))
-        .map(li => li.selectedSla)
+        .map(li => {
+          const sla = li.slas.find(sla => sla.id === li.selectedSla)
+
+          return sla.id + sla.shippingEstimate
+        })
     )
   )
 

--- a/react/__tests__/index.test.js
+++ b/react/__tests__/index.test.js
@@ -1,8 +1,5 @@
 import { CHEAPEST, DELIVERY } from '../constants'
-import {
-  getOptionsDetails,
-  getSelectedDeliveryOption,
-} from '../leanShipping'
+import { getOptionsDetails, getSelectedDeliveryOption } from '../leanShipping'
 import { removeAddressValidation } from '../utils'
 
 describe('getOptionDetails', () => {
@@ -39,6 +36,45 @@ describe('getOptionDetails', () => {
 
     expect(resultDetails).toEqual(expectedResult)
   })
+
+  it('should account for shipping estimate in packages length count', () => {
+    const delivery = {
+      [CHEAPEST]: [
+        {
+          selectedDeliveryChannel: DELIVERY,
+          selectedSla: 'Normal',
+          slas: [
+            {
+              id: 'Normal',
+              price: 100,
+              deliveryChannel: DELIVERY,
+              shippingEstimate: '1d',
+            },
+          ],
+        },
+        {
+          selectedDeliveryChannel: DELIVERY,
+          selectedSla: 'Normal',
+          slas: [
+            {
+              id: 'Normal',
+              price: 100,
+              deliveryChannel: DELIVERY,
+              shippingEstimate: '3d',
+            },
+          ],
+        },
+      ],
+    }
+
+    const details = getOptionsDetails(delivery)
+
+    expect(details).toStrictEqual([
+      expect.objectContaining({
+        packagesLength: 2,
+      }),
+    ])
+  })
 })
 
 describe('getSelectedDeliveryOption', () => {
@@ -72,35 +108,43 @@ describe('removeAddressValidation', () => {
   })
 
   it('should clean simple address object', () => {
-    expect(removeAddressValidation({
-      postalCode: {
-        value: 'abc123',
-      },
-    })).toStrictEqual({
+    expect(
+      removeAddressValidation({
+        postalCode: {
+          value: 'abc123',
+        },
+      })
+    ).toStrictEqual({
       postalCode: 'abc123',
     })
   })
 
   it('should not fail when address doesnt have validation', () => {
-    expect(removeAddressValidation({
-      postalCode: 'abc123',
-    })).toStrictEqual({
+    expect(
+      removeAddressValidation({
+        postalCode: 'abc123',
+      })
+    ).toStrictEqual({
       postalCode: 'abc123',
     })
   })
 
   it('should not fail when field is undefined', () => {
-    expect(removeAddressValidation({
-      postalCode: undefined,
-    })).toStrictEqual({
+    expect(
+      removeAddressValidation({
+        postalCode: undefined,
+      })
+    ).toStrictEqual({
       postalCode: undefined,
     })
   })
 
   it('should not fail when field value is undefined', () => {
-    expect(removeAddressValidation({
-      postalCode: { value: undefined },
-    })).toStrictEqual({
+    expect(
+      removeAddressValidation({
+        postalCode: { value: undefined },
+      })
+    ).toStrictEqual({
       postalCode: null,
     })
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Updates the logic for calculating the number of packages to also consider the SLA estimate, instead of only the ID.

#### What problem is this solving?

This fixes an issue where if you had a package with two SLAs with the same ID, 
but that in fact were two separate SLAs (delivered by two distinct sellers), 
this function would calculate that as being a single package instead of two.

The fix here should actually also consider the seller of the item being 
delivered, but unfortunately we don't have access to the item corresponding to 
each logistics info object.

#### How should this be manually tested?

You can test in [this workspace](https://lucas--ceacheckoutv6.myvtex.com/checkout/cart/add/?sku=3486850&qty=1&seller=zinzane&sc=1&sku=5145594&qty=1&seller=1&sc=1&sku=3243722&qty=1&seller=Britania&sc=1)

In the shipping step of checkout, you can see that it says "3 pacotes em prazos 
variados", which is what this PR focused on fixing.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
