### PR TITLE
Fix babel not clearing before build

### DIFF
--- a/react/package.json
+++ b/react/package.json
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "test": "cross-env NODE_ENV=test jest",
-    "build": "babel --config-file ./.build-babelrc.json . -d lib --extensions '.js','.ts'",
+    "build": "babel --config-file ./.build-babelrc.json . -d lib --delete-dir-on-start --extensions '.js','.ts'",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Adds `--delete-dir-on-start` flag to babel build command.

#### What problem is this solving?

The `lib` dir wasn't being deleted before build, making babel compile it again and include it "recursively" under the `lib` directory.

#### How should this be manually tested?

Run `yarn build` twice and make sure there isn't a `lib/lib` directory.

#### Screenshots or example usage

N/A

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
