### PR TITLE
[CHK-2201] - Fix pick up selection when switching between delivery and pick up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Pick up selection when switching between delivery and pickup with item only available for pickup.
 
 ## [0.2.19] - 2022-10-06
 ### Fixed

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -67,7 +67,7 @@ export function getNewLogisticsInfoIfPickup({
     if (defaultDeliverySla && hasMultipleItems) {
       return {
         ...logisticsInfo,
-        addressId:actionAddress.addressId,
+        addressId: actionAddress.addressId,
         selectedDeliveryChannel: DELIVERY,
         selectedSla: defaultDeliverySla.id
       }

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -32,7 +32,7 @@ export function getNewLogisticsInfoIfPickup({
 
   const hasFirstPickupSla =
     firstPickupSla &&
-    logisticsInfo.slas.some(sla => sla.id === firstPickupSla.id)
+    logisticsInfo.slas.some((sla) => sla.id === firstPickupSla.id)
 
   if (
     hasFirstPickupSla &&
@@ -51,7 +51,7 @@ export function getNewLogisticsInfoIfPickup({
 
   const defaultSlaSelection =
     logisticsInfo.slas.find(
-      sla => firstPickupSla && sla.id === firstPickupSla.id
+      (sla) => firstPickupSla && sla.id === firstPickupSla.id
     ) || findSlaWithChannel(logisticsInfo, channel)
 
   if (
@@ -69,16 +69,16 @@ export function getNewLogisticsInfoIfPickup({
         ...logisticsInfo,
         addressId: actionAddress.addressId,
         selectedDeliveryChannel: DELIVERY,
-        selectedSla: defaultDeliverySla.id
+        selectedSla: defaultDeliverySla.id,
       }
     }
 
-    if (activePickupPoint && activePickupPoint.id){
+    if (activePickupPoint && activePickupPoint.id) {
       return {
         ...logisticsInfo,
         addressId: actionSearchAddress.addressId,
         selectedDeliveryChannel: channel,
-        selectedSla: activePickupPoint.id
+        selectedSla: activePickupPoint.id,
       }
     }
 
@@ -86,7 +86,7 @@ export function getNewLogisticsInfoIfPickup({
       ...logisticsInfo,
       addressId: actionSearchAddress.addressId,
       selectedDeliveryChannel: channel,
-      selectedSla: null
+      selectedSla: null,
     }
   }
 
@@ -147,7 +147,7 @@ export function getNewLogisticsInfoIfDelivery({
   if (
     hasCurrentDeliveryChannel(logisticsInfo, channel) &&
     slaFromSlaOption &&
-    logisticsInfo.slas.some(sla => sla.id === slaFromSlaOption.id)
+    logisticsInfo.slas.some((sla) => sla.id === slaFromSlaOption.id)
   ) {
     return {
       ...logisticsInfo,
@@ -186,7 +186,7 @@ export function getNewLogisticsInfo({
   const actionAddress = removeAddressValidation(action.address)
   const actionSearchAddress = removeAddressValidation(action.searchAddress)
 
-  return newLogisticsInfo.map(li => {
+  return newLogisticsInfo.map((li) => {
     const hasSellerIdMatch = isFromCurrentSeller({ items, li, seller })
 
     if (!hasSellerIdMatch) {

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -63,16 +63,30 @@ export function getNewLogisticsInfoIfPickup({
       !defaultSlaSelection)
   ) {
     const defaultDeliverySla = findSlaWithChannel(logisticsInfo, DELIVERY)
+
+    if (defaultDeliverySla && hasMultipleItems) {
+      return {
+        ...logisticsInfo,
+        addressId:actionAddress.addressId,
+        selectedDeliveryChannel: DELIVERY,
+        selectedSla: defaultDeliverySla.id
+      }
+    }
+
+    if (activePickupPoint && activePickupPoint.id){
+      return {
+        ...logisticsInfo,
+        addressId: actionSearchAddress.addressId,
+        selectedDeliveryChannel: channel,
+        selectedSla: activePickupPoint.id
+      }
+    }
+
     return {
       ...logisticsInfo,
-      addressId:
-        defaultDeliverySla && hasMultipleItems
-          ? actionAddress.addressId
-          : actionSearchAddress.addressId,
-      selectedDeliveryChannel:
-        defaultDeliverySla && hasMultipleItems ? DELIVERY : channel,
-      selectedSla:
-        defaultDeliverySla && hasMultipleItems ? defaultDeliverySla.id : activePickupPoint && activePickupPoint.id,
+      addressId: actionSearchAddress.addressId,
+      selectedDeliveryChannel: channel,
+      selectedSla: null
     }
   }
 

--- a/react/logisticsInfo.js
+++ b/react/logisticsInfo.js
@@ -13,6 +13,7 @@ import {
 } from './utils'
 
 export function getNewLogisticsInfoIfPickup({
+  activePickupPoint,
   actionAddress,
   actionSearchAddress,
   channel,
@@ -71,7 +72,7 @@ export function getNewLogisticsInfoIfPickup({
       selectedDeliveryChannel:
         defaultDeliverySla && hasMultipleItems ? DELIVERY : channel,
       selectedSla:
-        defaultDeliverySla && hasMultipleItems ? defaultDeliverySla.id : null,
+        defaultDeliverySla && hasMultipleItems ? defaultDeliverySla.id : activePickupPoint && activePickupPoint.id,
     }
   }
 
@@ -180,6 +181,7 @@ export function getNewLogisticsInfo({
 
     if (isPickup(channel)) {
       const newLogisticsInfoIfPickup = getNewLogisticsInfoIfPickup({
+        activePickupPoint: action.activePickupPoint,
         action,
         actionAddress,
         actionSearchAddress,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds a fallback to the selection of SLA when switching between delivery and pick up with items only available for pick up.

#### What problem is this solving?
When the user selects a store for pick-up and when switching to delivery, when trying to return for pick-up another store returns selected,

if we alternate between delivery and pick-up sometimes the selected store initially appears times interspersing with another any store.

#### How should this be manually tested?
- Using this cart link: https://vtexgame1geo.myvtex.com/checkout/cart/add/?sku=341&qty=1&seller=1&sc=1

- For pick-up, search for “Rua Marques de Olinda 106” and select the store “Loja em Copacabana no Rio de Janeiro”

- Switch to delivery and update the address to “Avenida João Wallig” 

- Return for pickup

- Alternating between delivery and pickup it is possible to observe this behavior where the selected store initially has changed to another store.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
