### PR TITLE
chore: add test execution to CI pipeline

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -6,6 +6,9 @@
     pipelines:
       - name: node-ci-v2
         parameters:
+          nodeCommands:
+            - install
+            - test:coverage
           sonarProjectName: lean-shipping-calculator
           nodeVersion: 20-bookworm
         runtime:

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "scripts": {
     "test": "yarn --cwd react test",
-    "lint": "eslint --ext js,ts,jsx,tsx ."
+    "lint": "eslint --ext js,ts,jsx,tsx .",
+    "test:coverage": "yarn --cwd react install --frozen-lockfile && yarn --cwd react test:coverage"
   },
   "keywords": [],
   "author": "",

--- a/react/package.json
+++ b/react/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "test": "cross-env NODE_ENV=test jest",
     "build": "babel --config-file ./.build-babelrc.json . -d lib --delete-dir-on-start --extensions '.js','.ts'",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@vtex/delivery-packages": "^2.17.0",


### PR DESCRIPTION
## Summary
- Add `test:coverage` script to package.json
- Add `nodeCommands` with test step to `.vtex/deployment.yaml` so CI runs tests on PRs

## Context
Part of test-execution rollout for Checkout Experience repos. Goal: every repo runs its test suite on every PR via DK CI.

## Test plan
- [ ] Verify pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify test step executes (or stub passes if no tests)
- [ ] Confirm no regressions in existing pipeline steps

> **Note:** Any pre-existing CI failures on this repo are unrelated to this change.
